### PR TITLE
Revert Android compileSdkVersion back to 30 as temporary fix for Android 12 incompatibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.2
+
+* Revert Android compileSdkVersion back to 30 as temporary fix for Android 12 incompatibilities
+
 ## 2.5.1
 
 * Update Android compileSdkVersion to 31

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 18

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 30
 
     lintOptions {
         disable 'InvalidPackage'
@@ -34,7 +34,7 @@ android {
     defaultConfig {
         applicationId "com.polidea.flutter_ble_lib_example"
         minSdkVersion 18
-        targetSdkVersion 31
+        targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ble_lib_ios_15
 description: FlutterBle Library is a flutter library that supports BLE operations. It uses MultiPlatformBleAdapter as a native backend. Forked from https://github.com/Polidea/FlutterBleLib to support iOS 15.
-version: 2.5.1
+version: 2.5.2
 homepage: https://github.com/davejlin/flutter_ble_lib_ios_15
 
 environment:


### PR DESCRIPTION
Revert Android compileSdkVersion back to 30 as temporary fix for Android 12 incompatibilities