### PR TITLE
Fix/dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0
+
+* Upgraded MultiPlatformBleAdapter dependency to a fork to support Android 12 and above
+
 ## 2.5.2
 
 * Revert Android compileSdkVersion back to 30 as temporary fix for Android 12 incompatibilities

--- a/README.md
+++ b/README.md
@@ -14,15 +14,14 @@ The main change is to specify version 0.1.9 for the dependency MultiplatformBleA
   s.dependency 'MultiplatformBleAdapter', '~> 0.1.9'
 ```
 
-In your Flutter project, specify the following in ```.../ios/Podfile``` to point to the forked MultiplatformBleAdapter repo to use the correct version:
+Furthermore, to resolve some issues surrounding newer Android versions, the MultiPlatformBleAdapter dependency for 
+Android has been updated to use [this fork](https://github.com/MY01Inc/MultiPlatformBleAdapter/tree/main). This 
+repository was chosen after considering a number of forks, as it is relatively up-to-date, fixes the issues with newer 
+Android versions, and has a working build on [JitPack](https://jitpack.io/#MY01Inc/MultiPlatformBleAdapter). This
+resulted in the following dependency change:
 
 ```
-target 'Runner' do
-  use_frameworks!
-  use_modular_headers!
-  pod 'MultiplatformBleAdapter', :git => 'https://github.com/below/MultiPlatformBleAdapter', :tag => '0.1.9'
-  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-end
+implementation 'com.github.MY01Inc:MultiPlatformBleAdapter:73f8ea5fdf'
 ```
 
 To be consistent with the parent project, versioning in this fork begins at ```2.4.1```
@@ -30,7 +29,7 @@ To be consistent with the parent project, versioning in this fork begins at ```2
 # FlutterBleLib
 
 A library for all your Bluetooth Low Energy needs in Flutter. Internally utilises Polidea's
-[MultiPlatformBleAdapter](https://github.com/Polidea/MultiPlatformBleAdapter),
+[MultiPlatformBleAdapter](https://github.com/Polidea/MultiPlatformBleAdapter) for iOS and MY01Inc's [MultiPlatformBleAdapter](https://github.com/MY01Inc/MultiPlatformBleAdapter/tree/main) for Android,
 which runs on [RxAndroidBle](https://github.com/Polidea/RxAndroidBle)
 and [RxBluetoothKit](https://github.com/Polidea/RxBluetoothKit).
 
@@ -41,16 +40,16 @@ The simulation allows one to develop without physical smartphone or BLE peripher
 
 ## Installation
 
-To use this plugin, add `flutter_ble_lib` as a [dependency in your pubspec.yaml file](https://flutter.dev/docs/development/packages-and-plugins/using-packages).
+To use this plugin, add `flutter_ble_lib_ios_15` as a [dependency in your pubspec.yaml file](https://flutter.dev/docs/development/packages-and-plugins/using-packages).
 
 ### Android
 
-Set `minSDKVersion` in `[project]/android/app/build.gradle` file to 18.
+Set `minSDKVersion` in `[project]/android/app/build.gradle` file to 21.
 
 ```gradle
 defaultConfig {
   ...
-  minSdkVersion 18
+  minSdkVersion 21
   ...
 }
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,23 +4,24 @@ version '2.3.2'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'idea'
 
 android {
     compileSdkVersion 30

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.polidea.flutter_ble_lib'
-version '2.3.2'
+version '2.6.0'
 
 buildscript {
     repositories {
@@ -36,6 +36,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.github.Polidea:MultiPlatformBleAdapter:0.1.8'
+    implementation 'androidx.annotation:annotation:1.6.0'
+    implementation 'com.github.MY01Inc:MultiPlatformBleAdapter:73f8ea5fdf'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip

--- a/example/lib/device_details/device_details_bloc.dart
+++ b/example/lib/device_details/device_details_bloc.dart
@@ -7,8 +7,6 @@ import 'package:flutter_ble_lib_example/repository/device_repository.dart';
 import 'package:flutter_ble_lib_example/test_scenarios/test_scenarios.dart';
 import 'package:rxdart/rxdart.dart';
 
-import '../model/ble_device.dart';
-import '../repository/device_repository.dart';
 
 class DeviceDetailsBloc {
   final BleManager _bleManager;
@@ -25,7 +23,7 @@ class DeviceDetailsBloc {
 
   Stream<List<DebugLog>> get logs => _logsController.stream;
 
-  Stream<Null?> get disconnectedDevice => _deviceRepository.pickedDevice
+  Stream<Null> get disconnectedDevice => _deviceRepository.pickedDevice
       .skipWhile((bleDevice) => bleDevice != null)
       .cast<Null>();
 

--- a/example/lib/device_details/view/button_view.dart
+++ b/example/lib/device_details/view/button_view.dart
@@ -11,9 +11,11 @@ class ButtonView extends StatelessWidget {
     return Expanded(
       child: Padding(
         padding: const EdgeInsets.all(2.0),
-        child: RaisedButton(
-          color: Colors.blue,
-          textColor: Colors.white,
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.blue,
+            foregroundColor: Colors.white,
+          ),
           child: Text(_text),
           onPressed: action,
         ),

--- a/example/lib/devices_list/devices_list_view.dart
+++ b/example/lib/devices_list/devices_list_view.dart
@@ -143,7 +143,7 @@ class DevicesList extends ListView {
               padding: const EdgeInsets.all(8.0),
               child: Image.asset('assets/ti_logo.png'),
             ),
-            backgroundColor: Theme.of(context).accentColor);
+            backgroundColor: Theme.of(context).colorScheme.secondary);
       case DeviceCategory.hex:
         return CircleAvatar(
             child: CustomPaint(painter: HexPainter(), size: Size(20, 24)),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,7 +20,7 @@ class MyApp extends StatelessWidget {
       title: 'FlutterBleLib example',
       theme: new ThemeData(
         primaryColor: new Color(0xFF0A3D91),
-        accentColor: new Color(0xFFCC0000),
+        hintColor: new Color(0xFFCC0000),
       ),
       initialRoute: "/",
       routes: <String, WidgetBuilder>{

--- a/ios/flutter_ble_lib_ios_15.podspec
+++ b/ios/flutter_ble_lib_ios_15.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_ble_lib_ios_15'
-  s.version          = '2.4.1'
+  s.version          = '2.6.0'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/lib/flutter_ble_lib.dart
+++ b/lib/flutter_ble_lib.dart
@@ -41,7 +41,6 @@ import 'package:flutter_ble_lib_ios_15/src/_internal.dart';
 import 'package:flutter_ble_lib_ios_15/src/_managers_for_classes.dart';
 import 'package:flutter_ble_lib_ios_15/src/util/_transaction_id_generator.dart';
 
-import 'src/_managers_for_classes.dart';
 
 part 'error/ble_error.dart';
 

--- a/lib/scan_result.dart
+++ b/lib/scan_result.dart
@@ -38,7 +38,7 @@ class ScanResult {
 
 
   factory ScanResult.fromJson(
-    Map<String, dynamic?> json, 
+    Map<String, dynamic> json, 
     ManagerForPeripheral manager
   ) {
     assert(json[_ScanResultMetadata.rssi] is int);

--- a/lib/src/_internal.dart
+++ b/lib/src/_internal.dart
@@ -2,7 +2,6 @@ library _internal;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ble_lib_ios_15
 description: FlutterBle Library is a flutter library that supports BLE operations. It uses MultiPlatformBleAdapter as a native backend. Forked from https://github.com/Polidea/FlutterBleLib to support iOS 15.
-version: 2.5.2
+version: 2.6.0
 homepage: https://github.com/davejlin/flutter_ble_lib_ios_15
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,16 +9,16 @@ environment:
   flutter: ">=1.10.0"
 
 dependencies:
-  collection: ^1.15.0
-  async: ^2.5.0
-  meta: ^1.3.0
+  collection: ^1.17.1
+  async: ^2.11.0
+  meta: ^1.9.1
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  mockito: ^5.0.3
-  build_runner: ^1.12.2
-  pedantic: ^1.11.0
+  mockito: ^5.4.1
+  build_runner: ^2.4.4
+  pedantic: ^1.11.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
This merge request is aimed to resolve issues regarding permissions in Android 12 and above.

The README has been updated and explains some of the changes made.

The MultiPlatformBleAdapter dependency for Android has been changed to [a fork](https://github.com/MY01Inc/MultiPlatformBleAdapter) which has been updated recently and is available through JitPack.io. Other forks were considered, but didn't match certain requirements or didn't have a valid build in JitPack